### PR TITLE
Add persistent Claude Code settings configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "enableAllProjectMcpServers": true,
+  "permissions": {
+    "allow": [
+      "Bash(./scripts/qa.sh:*)",
+      "Bash(./target/debug/fezinator:*)",
+      "Bash(./target/debug/test-asm:*)",
+      "Bash(./target/release/fezinator analyze:*)",
+      "Bash(./target/release/fezinator list)",
+      "Bash(./target/release/fezinator remove:*)",
+      "Bash(./target/release/fezinator extract:*)",
+      "Bash(cargo:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git init:*)",
+      "Bash(git push:*)",
+      "Bash(ld:*)",
+      "Bash(ls:*)",
+      "Bash(make:*)",
+      "Bash(mkdir:*)",
+      "Bash(nasm:*)",
+      "Bash(objdump:*)",
+      "Bash(python3:*)",
+      "Bash(rm:target/*)",
+      "Bash(sqlite3:*)",
+      "WebFetch(*)"
+    ],
+    "deny": [
+      "Bash(git push --force:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add persistent Claude Code settings configuration in `.claude/settings.json`
- Consolidate all Claude Code permissions from local settings

## Changes
- Created `.claude/settings.json` with project permissions and configuration
- Includes all necessary permissions for the project tools (cargo, git, make, etc.)

## Test plan
- [x] Verify Claude Code settings are properly loaded
- [x] Ensure all project tools have appropriate permissions

🤖 Generated with [Claude Code](https://claude.ai/code)